### PR TITLE
Fixed use of deprecated function in ImGui 'GetContentRegionAvailWidth'

### DIFF
--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -612,7 +612,7 @@ void CommandPalette(const char* name)
         auto id = window->GetID(static_cast<int>(i));
 
         ImVec2 size{
-            ImGui::GetContentRegionAvailWidth(),
+            ImGui::GetContentRegionAvail().x,
             ImMax(font_regular->FontSize, font_highlight->FontSize),
         };
         ImRect rect{


### PR DESCRIPTION
This function was removed in ImGui master (with 1.87 being it's release), and deprecated somewhere in the '1.69, 1.70, 1.71, 1.72' era of imgui (the changelog isn't specific).  

This should build just fine in 1.85, which the example targets and wont break when 1.87 comes out.