### PR TITLE
Handle FontScale for macOS retina

### DIFF
--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -161,7 +161,7 @@ struct Context
             Commands.end(),
             command,
             [](const Command& a, const Command& b) -> bool {
-                return strcmp(a.Name, b.Name) < 0;
+                return strcmp(a.Name.c_str(), b.Name.c_str()) < 0;
             });
         Commands.insert(location, std::move(command));
     }
@@ -172,12 +172,12 @@ struct Context
         {
             bool operator()(const Command& command, const char* str) const
             {
-                return strcmp(command.Name, str) < 0;
+                return strcmp(command.Name.c_str(), str) < 0;
             }
 
             bool operator()(const char* str, const Command& command) const
             {
-                return strcmp(str, command.Name) < 0;
+                return strcmp(str, command.Name.c_str()) < 0;
             }
         };
 
@@ -266,7 +266,7 @@ const char* ExecutionManager::GetItem(int idx) const
     if (m_ExecutingCommand) {
         return m_CallStack.back().Options[idx].c_str();
     } else {
-        return gContext->Commands[idx].Name;
+        return gContext->Commands[idx].Name.c_str();
     }
 }
 

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -654,9 +654,11 @@ void CommandPalette(const char* name)
 
                 auto begin = text + range_begin;
                 auto end = text + range_end;
-                draw_list->AddText(font_highlight, font_highlight->FontSize, text_pos, text_color_highlight, begin, end);
 
-                auto segment_size = font_highlight->CalcTextSizeA(font_highlight->FontSize, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                float fontScale = ImGui::GetIO().FontGlobalScale; // could be 0.5 on macOS Retina, 1 elsewhere
+                draw_list->AddText(font_highlight, font_highlight->FontSize * fontScale, text_pos, text_color_highlight, begin, end);
+                auto segment_size = font_highlight->CalcTextSizeA(font_highlight->FontSize * fontScale, std::numeric_limits<float>::max(), 0.0f, begin, end);
+
                 text_pos.x += segment_size.x;
             };
 

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -21,7 +21,7 @@ namespace ImCmd
 {
 struct Command
 {
-    const char* Name;
+    std::string Name;
     std::function<void()> InitialCallback;
     std::function<void(int selected_option)> SubsequentCallback;
     std::function<void()> TerminatingCallback;


### PR DESCRIPTION
Hello, and happy new year!

I'm working on adding your project, and I stumbled on this issue. On Mac Retina screen, I was having a layout like this:

<img width="251" alt="image" src="https://user-images.githubusercontent.com/7694091/210263488-f403209a-48a7-47c8-8447-17c34df56c6e.png">

This is when handling highDPI with imgui: macOS "hides" the DPI, and we are using virtual pixels (i.e the screen is seen as being 1280x720 instead of 2560x1440)
=> Fonts are loaded at twice the size, and then resized before being displayed.

FontGlobalScale is used almost only on MacOS. On Windows and Linux, imgui uses the real pixel sizes.

With this patch, I can obtain:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/7694091/210263829-eecaa3c5-be25-4684-99f3-b58d88b6d8fc.png">
