### PR TITLE
Fixed Segmentation Fault when CMD list is empty

### DIFF
--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -742,7 +742,7 @@ void CommandPalette(const char* name)
     }
     if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter)) || select_focused_item) {
         if(!gi.Search.GetItemCount() || gi.Search.SearchResults.empty()){
-            // aEssentially don't execute any commands.
+            // Essentially don't execute any commands.
         }else if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
             auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
             gi.Session.SelectItem(idx);

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -741,7 +741,9 @@ void CommandPalette(const char* name)
         gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
     }
     if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter)) || select_focused_item) {
-        if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
+        if(!gi.Search.GetItemCount() || gi.Search.SearchResults.empty()){
+            // aEssentially don't execute any commands.
+        }else if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
             auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
             gi.Session.SelectItem(idx);
         } else {

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -275,7 +275,7 @@ void ExecutionManager::SelectItem(int idx)
     size_t initial_call_stack_height = m_CallStack.size();
 
     // Guarding aginst invalid index.
-    if(idx >= gContext->Commands.size()) return;
+    if (idx >= gContext->Commands.size()) return;
     IM_ASSERT(idx < gContext->Commands.size());
 
     if (cmd == nullptr) {

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -273,6 +273,11 @@ void ExecutionManager::SelectItem(int idx)
 {
     auto cmd = m_ExecutingCommand;
     size_t initial_call_stack_height = m_CallStack.size();
+
+    // Guarding aginst invalid index.
+    if(idx >= m_CallStack.size()) return;
+    IM_ASSERT(idx < m_CallStack.size());
+
     if (cmd == nullptr) {
         cmd = m_ExecutingCommand = &gContext->Commands[idx];
         ++gContext->CommandStorageLocks;
@@ -741,9 +746,7 @@ void CommandPalette(const char* name)
         gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
     }
     if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter)) || select_focused_item) {
-        if(!gi.Search.GetItemCount() || gi.Search.SearchResults.empty()){
-            // Essentially don't execute any commands.
-        }else if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
+        if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
             auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
             gi.Session.SelectItem(idx);
         } else {

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -275,8 +275,8 @@ void ExecutionManager::SelectItem(int idx)
     size_t initial_call_stack_height = m_CallStack.size();
 
     // Guarding aginst invalid index.
-    if(idx >= m_CallStack.size()) return;
-    IM_ASSERT(idx < m_CallStack.size());
+    if(idx >= gContext->Commands.size()) return;
+    IM_ASSERT(idx < gContext->Commands.size());
 
     if (cmd == nullptr) {
         cmd = m_ExecutingCommand = &gContext->Commands[idx];


### PR DESCRIPTION
When one brings up a command palette without any commands registered, and press enter. The application will segfault.

I have identified and fixed the place where this happen. I've added a check to see if the search is empty or when the search result is empty, then it does nothing.